### PR TITLE
T6 80 compare hashes return tampered areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 app/backend/Scripts/pdf-test.pdf
+app/backend/Scripts/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 app/backend/Scripts/pdf-test.pdf
 app/backend/Scripts/__pycache__
+.pytest_cache
+.coverage

--- a/app/backend/Scripts/test_transformer.py
+++ b/app/backend/Scripts/test_transformer.py
@@ -1,2 +1,18 @@
 from transformer import Transformer as tf
 from pathlib import Path
+
+pdfImages = tf.pdf_as_images('app/backend/Scripts/pdf-test.pdf')
+
+# Check same hasharray
+hasharray1 = tf.images_to_hash_array(pdfImages)
+hasharray2 = tf.images_to_hash_array(pdfImages)
+print(tf.compare_document_hashes(hasharray1, hasharray2))
+
+# Check different hasharrays
+hasharray2[0][1] = 'a'
+hasharray2[1][1] = 'b'
+print(tf.compare_document_hashes(hasharray1, hasharray2))
+
+# Check different size hasharrays
+hasharray2.append(['a'])
+print(tf.compare_document_hashes(hasharray1, hasharray2))

--- a/app/backend/Scripts/test_transformer.py
+++ b/app/backend/Scripts/test_transformer.py
@@ -1,10 +1,10 @@
-from Transformer import Transformer as tf
-from PIL import Image
+from transformer import Transformer as tf
+from pathlib import Path
 
 # TEST FILE
 
-inf = "/home/huy/Desktop/isml_stuff/cover7-converted.pdf"
-outf = "/home/huy/Documents"
+inputFile = "app/backend/Scripts/pdf-test.pdf"
+tempLocation = "/home/huy/Documents"
 
 with open("/home/huy/Desktop/isml_stuff/cover7-converted.pdf", 'rb') as pdf_file:
     images = pdf_file.read()

--- a/app/backend/Scripts/test_transformer.py
+++ b/app/backend/Scripts/test_transformer.py
@@ -1,13 +1,2 @@
 from transformer import Transformer as tf
 from pathlib import Path
-
-# TEST FILE
-
-inputFile = "app/backend/Scripts/pdf-test.pdf"
-tempLocation = "/home/huy/Documents"
-
-with open("/home/huy/Desktop/isml_stuff/cover7-converted.pdf", 'rb') as pdf_file:
-    images = pdf_file.read()
-
-a = tf.bytes_to_hash_array(images)
-print(a)

--- a/app/backend/Scripts/test_transformer.py
+++ b/app/backend/Scripts/test_transformer.py
@@ -1,18 +1,19 @@
 from transformer import Transformer as tf
 from pathlib import Path
 
-pdfImages = tf.pdf_as_images('app/backend/Scripts/pdf-test.pdf')
+def test_compare_document_hashes():
+    pdfImages = tf.pdf_as_images('app/backend/Scripts/pdf-test.pdf')
 
-# Check same hasharray
-hasharray1 = tf.images_to_hash_array(pdfImages)
-hasharray2 = tf.images_to_hash_array(pdfImages)
-print(tf.compare_document_hashes(hasharray1, hasharray2))
+    # Check same hasharray
+    hasharray1 = tf.images_to_hash_array(pdfImages)
+    hasharray2 = tf.images_to_hash_array(pdfImages)
+    print(tf.compare_document_hashes(hasharray1, hasharray2))
 
-# Check different hasharrays
-hasharray2[0][1] = 'a'
-hasharray2[1][1] = 'b'
-print(tf.compare_document_hashes(hasharray1, hasharray2))
+    # Check different hasharrays
+    hasharray2[0][1] = 'a'
+    hasharray2[1][1] = 'b'
+    print(tf.compare_document_hashes(hasharray1, hasharray2))
 
-# Check different size hasharrays
-hasharray2.append(['a'])
-print(tf.compare_document_hashes(hasharray1, hasharray2))
+    # Check different size hasharrays
+    hasharray2.append(['a'])
+    print(tf.compare_document_hashes(hasharray1, hasharray2))

--- a/app/backend/Scripts/transformer.py
+++ b/app/backend/Scripts/transformer.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 class Transformer():
-    
+
     #read pdf from file path and convert to jpegs
     def pdf_to_image(inputPath:str, outputPath:str):
         if not path.exists(outputPath):
@@ -16,7 +16,7 @@ class Transformer():
             fileName = outputPath + 'output' + str(pageNum)
             page.save(fileName, "JPEG")
         return pdfAsImages
-    
+
     #read pdf from byte input and convert to jpegs
     def bytes_to_images(bytes:bytes):
         pdfAsImages = convert_from_bytes(bytes)
@@ -29,7 +29,7 @@ class Transformer():
             pageAsNumpy = np.asarray(page)
             pagesAsNumpy.append(pageAsNumpy)
         return pagesAsNumpy
-    
+
     #separate a page into 18 separate chunks
     def PDF_to_Numpy(imagesAsNumpy: list, chunks: int=18) -> list:
         chunkedImages = []
@@ -59,7 +59,7 @@ class Transformer():
         hashArray = Transformer.encrypt_document(npArray)
         return hashArray
 
-    # compares hash array lists
+    #compares hash array lists
     def compare_document_hashes(original: list, toVerify: list):
         tamperedRegions = []
         if len(original) == len(toVerify):

--- a/app/backend/Scripts/transformer.py
+++ b/app/backend/Scripts/transformer.py
@@ -17,7 +17,7 @@ class Transformer():
             page.save(fileName, "JPEG")
         return pdfAsImages
 
-    def pdf_as_image(inputPath: str):
+    def pdf_as_images(inputPath: str):
         pdfAsImages = convert_from_path(inputPath)
         return pdfAsImages
 
@@ -51,8 +51,10 @@ class Transformer():
     def encrypt_document(input:list):
         encryptedPages = []
         for page in input:
+            currentPage = []
             for chunk in page:
-                encryptedPages.append(Transformer.encrypt_data(chunk))
+                currentPage.append(Transformer.encrypt_data(chunk))
+            encryptedPages.append(currentPage)
         return encryptedPages
 
     #converts bytes to array of SHA256 hash strings
@@ -74,8 +76,8 @@ class Transformer():
         tamperedRegions = []
         if len(original) == len(toVerify):
             for pageNum in range(len(original)):
-                for chunkNum in range(original[pageNum]):
-                    if original[chunkNum] != toVerify[chunkNum]:
+                for chunkNum in range(len(original[pageNum])):
+                    if original[pageNum][chunkNum] != toVerify[pageNum][chunkNum]:
                         tamperedRegions.append([pageNum, chunkNum])
             if bool(tamperedRegions):
                 return tamperedRegions

--- a/app/backend/Scripts/transformer.py
+++ b/app/backend/Scripts/transformer.py
@@ -7,7 +7,7 @@ import numpy as np
 class Transformer():
 
     #read pdf from file path and convert to jpegs
-    def pdf_to_image(inputPath:str, outputPath:str):
+    def save_pdf_as_image(inputPath:str, outputPath:str):
         if not path.exists(outputPath):
             makedirs(outputPath)
 
@@ -15,6 +15,10 @@ class Transformer():
         for pageNum, page in enumerate(pdfAsImages):
             fileName = outputPath + 'output' + str(pageNum)
             page.save(fileName, "JPEG")
+        return pdfAsImages
+
+    def pdf_as_image(inputPath: str):
+        pdfAsImages = convert_from_path(inputPath)
         return pdfAsImages
 
     #read pdf from byte input and convert to jpegs
@@ -54,6 +58,12 @@ class Transformer():
     #converts bytes to array of SHA256 hash strings
     def bytes_to_hash_array(bytes:bytes):
         images = Transformer.bytes_to_images(bytes)
+        pilArray = Transformer.PIL_to_Numpy(images)
+        npArray = Transformer.PDF_to_Numpy(pilArray)
+        hashArray = Transformer.encrypt_document(npArray)
+        return hashArray
+
+    def images_to_hash_array(images:list):
         pilArray = Transformer.PIL_to_Numpy(images)
         npArray = Transformer.PDF_to_Numpy(pilArray)
         hashArray = Transformer.encrypt_document(npArray)

--- a/app/backend/Scripts/transformer.py
+++ b/app/backend/Scripts/transformer.py
@@ -1,8 +1,8 @@
 from pdf2image import convert_from_path, convert_from_bytes
-from PIL import Image
 from os import path, makedirs
-import numpy as np
 from hashlib import sha256
+import numpy as np
+
 
 class Transformer():
     
@@ -58,3 +58,14 @@ class Transformer():
         npArray = Transformer.PDF_to_Numpy(pilArray)
         hashArray = Transformer.encrypt_document(npArray)
         return hashArray
+
+    def compare_document_hashes(original: list, toVerify: list):
+        tamperedRegions = []
+        if len(original) == len(toVerify):
+            for pageNum in range(len(original)):
+                for chunkNum in range(original[pageNum]):
+                    if original[chunkNum] != toVerify[chunkNum]:
+                        tamperedRegions.append([pageNum, chunkNum])
+            return tamperedRegions
+        else:
+            return 0

--- a/app/backend/Scripts/transformer.py
+++ b/app/backend/Scripts/transformer.py
@@ -59,6 +59,7 @@ class Transformer():
         hashArray = Transformer.encrypt_document(npArray)
         return hashArray
 
+    # compares hash array lists
     def compare_document_hashes(original: list, toVerify: list):
         tamperedRegions = []
         if len(original) == len(toVerify):
@@ -66,6 +67,8 @@ class Transformer():
                 for chunkNum in range(original[pageNum]):
                     if original[chunkNum] != toVerify[chunkNum]:
                         tamperedRegions.append([pageNum, chunkNum])
-            return tamperedRegions
+            if bool(tamperedRegions):
+                return tamperedRegions
         else:
-            return 0
+            return 1
+        return 0


### PR DESCRIPTION
- New Function: compare_document_hashes
- Indicates indexes [Image Number, Chunk Number] where tampered
- Return 1 if documents are not the same length
- Return 0 if clear