### PR TITLE
Cleaning up table and button styles on verify page

### DIFF
--- a/app/backend/public/css/verify.css
+++ b/app/backend/public/css/verify.css
@@ -10,17 +10,15 @@
 	float: left;
 }
 
-.container-fluid {
-    padding-left: 5%;
-    padding-right: 5%;
+.compareBtn {
+	border-radius: 5px;
+    margin-top: 6px;
+    background-color: #f0ffe6;
+	border-color: #8fdd60;
 }
 
 .divider {
     height: 3rem;
-}
-
-.dropdown {
-    float: right;
 }
 
 .tampering{
@@ -28,32 +26,18 @@
     flex-direction: column;
 }
 
-/* https://css-tricks.com/table-borders-inside/ */
+.page-item.active .page-link {
+	color: rgb(0, 0, 0);
+	background-color: #c0ff96;
+	border-color: #8fdd60;
+}
+
 .table {
 	width: 100%;
-    background-color: #eeeeee;
+    background-color: #fafafa;
     border-color: white;
     border-collapse: collapse;
     border-style: hidden;
-}
-
-.table th {
-    border-width: 3px;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	max-width: 1px;
-}
-
-.table tr {
-    border-top-width: 10px;
-}
-
-.table td {
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	max-width: 1px;
 }
 
 @media all and (max-width: 400px){

--- a/app/backend/public/js/verify.js
+++ b/app/backend/public/js/verify.js
@@ -10,7 +10,8 @@
         console.log(document.querySelectorAll("#myTable"))
         $('#myTable').DataTable({
             columnDefs: [
-                { orderable: false, targets: 3 }
+                { orderable: false, targets: 3 },
+                { "width": "10%", "targets": 3}
             ]
         });
     });
@@ -30,7 +31,7 @@ renderData = (obj) => {
         <form id="compare">
         <div class="tampering">
         <input type="file" name="pdf"/>
-        <button type="button" onclick="compareFile()"> Get This File </button>
+        <button type="button" class="btn compareBtn" onclick="compareFile()"> Compare File </button>
         </div>
         </form>
         `;

--- a/app/html/verify.html
+++ b/app/html/verify.html
@@ -4,11 +4,12 @@
     <title>Verify Documents</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.0.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.1/css/dataTables.bootstrap5.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/dataTables.bootstrap5.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.0.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="css/verify.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="js/verify.js"></script>
     <link rel="shortcut icon" type="image/jpg" href="media/favicon.ico"/>
 </head>
 
@@ -39,7 +40,7 @@
     </nav> 
     <div class="divider"></div>
     <!--Buttons above table-->
-    <div class="container-fluid">
+    <div class="container">
         <div class="row">
             <!-- Verify Button -->
             <div class="col">
@@ -49,26 +50,23 @@
     </div>
     <div class="divider"></div>
     <!--Table-->
-    <div class="container-fluid">
-        <table class="table table-striped" id="myTable">
+    <div class="container">
+        <table class="table table-striped" id="myTable" style="width:100%">
             <thead>
                 <tr>
                     <th scope="col">Date</th>
                     <th scope="col">Name</th>
                     <th scope="col">TxHash</th>
-                    <th scope="col">Check for tampering</th>
+                    <th scope="col">Verify</th>
                 </tr>
             </thead>
             <tbody>
             </tbody>
         </table>
     </div>
-
-    <!-- JavaScript Bundle with Popper -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj" crossorigin="anonymous"></script>
+    <div class="divider"></div>
     <!--Script for datatables-->
-    <script src="https://cdn.datatables.net/1.11.1/js/jquery.dataTables.min.js" defer ></script>
-    <script src="https://cdn.datatables.net/1.11.1/js/dataTables.bootstrap5.min.js"></script>
-    <script src="js/verify.js"></script>
+    <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.11.3/js/dataTables.bootstrap5.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Changes:
- Table width now lines up with navbar contents
- Show x entries and search box are now inline
- Fixed page buttons
- Renamed "Get This File" to "Compare File" to better reflect functionality